### PR TITLE
Fix colors and add help and version usage flags

### DIFF
--- a/handbook.py
+++ b/handbook.py
@@ -5,6 +5,8 @@ Dispatcher for commands to build and maintain the Software Engineering Handbook.
 
 Usage:
   handbook [options] <command> [<args>...]
+  handbook (-h|--help)
+  handbook (-v|--version)
 
 Options:
   -h, --help        show this help message and exit
@@ -39,7 +41,7 @@ def main():
 
 def appendCommandsAndSummariesToUsage(usage, commands):
     """"""
-    styleForeGreen = '\x1b[0;32;40m'
+    styleForeGreen = '\x1b[0;32m'
     styleResetAll = '\x1b[0m'
     commandsAndSummaries = ''
     for name, module in commands.items():


### PR DESCRIPTION
This PR removes the background color of the commands and adds --help and --version to the initial usage patterns, so that they are shown when running the handbook without arguments.
